### PR TITLE
Do not try to redirect if provided canonical host is nil or empty

### DIFF
--- a/lib/plug_canonical_host.ex
+++ b/lib/plug_canonical_host.ex
@@ -26,7 +26,8 @@ defmodule PlugCanonicalHost do
   @doc """
   Call the plug.
   """
-  def call(conn = %Plug.Conn{host: host}, [canonical_host: canonical_host]) when host !== canonical_host do
+  def call(conn = %Plug.Conn{host: host}, [canonical_host: canonical_host])
+    when is_nil(canonical_host) == false and canonical_host !== "" and host !== canonical_host do
     location = conn |> redirect_location(canonical_host)
 
     conn

--- a/test/plug_canonical_host_test.exs
+++ b/test/plug_canonical_host_test.exs
@@ -34,4 +34,18 @@ defmodule PlugCanonicalHostTest do
     assert conn.status == 200
     assert conn.resp_body == "Hello World"
   end
+
+  test "does not redirect when canonical host is an empty string" do
+    conn = %Plug.Conn{host: "www.example.com", status: 200}
+    |> PlugCanonicalHost.call(canonical_host: "")
+
+    assert conn.status == 200
+  end
+
+  test "does not redirect when canonical host is nil" do
+    conn = %Plug.Conn{host: "www.example.com", status: 200}
+    |> PlugCanonicalHost.call(canonical_host: nil)
+
+    assert conn.status == 200
+  end
 end


### PR DESCRIPTION
Providing `canonical_host: ""` or `canonical_host: nil` (eg. if a user has misconfigured the plug) would lead to unexpected behavior. We’re better off ignoring requests then.