### PR TITLE
Support {:system, env_var} notation for loading config from ENV.

### DIFF
--- a/lib/plug_canonical_host.ex
+++ b/lib/plug_canonical_host.ex
@@ -40,8 +40,14 @@ defmodule PlugCanonicalHost do
   Call the plug.
   """
   @spec call(%Conn{}, opts) :: %Conn{}
+  def call(conn = %Conn{host: _host}, {:system, env_var}) do
+    canonical_host = System.get_env(env_var)
+    call(conn, canonical_host)
+  end
+  @spec call(%Conn{}, opts) :: %Conn{}
   def call(conn = %Conn{host: host}, canonical_host)
     when is_nil(canonical_host) == false and canonical_host !== "" and host !== canonical_host do
+
     location = conn |> redirect_location(canonical_host)
 
     conn


### PR DESCRIPTION
We would like to load the CANONICAL_HOST from the environment, since we're using the same compiled app across two envs (stage and prod). I couldn't find an easy way to do this, as the combination of compilation and `plug` macro expansion results in the fetch'd value being compiled in to the Endpoint.

The `{:system, env_var}` convention is a phoenix thing that I think other people have adopted.

This PR maintains the old functionality while also allowing configuration like this:

```
defmodule PhoenixApp.Endpoint do
  use Phoenix.Endpoint, otp_app: :phoenix_app
  plug PlugCanonicalHost, canonical_host: {:system, "CANONICAL_HOST"}
end
```

What do yo think? If you're into it, I will add some tests.
