### PR TITLE
add support for x-forwarded-proto

### DIFF
--- a/lib/plug_canonical_host.ex
+++ b/lib/plug_canonical_host.ex
@@ -15,6 +15,7 @@ defmodule PlugCanonicalHost do
   # Constants
   @location_header "location"
   @forwarded_port_header "x-forwarded-port"
+  @forwarded_proto_header "x-forwarded-proto"
   @status_code 301
   @html_template """
     <!DOCTYPE html>
@@ -63,7 +64,7 @@ defmodule PlugCanonicalHost do
 
   @spec request_uri(%Conn{}) :: String.t()
   defp request_uri(conn = %Conn{scheme: scheme, host: host, request_path: request_path, query_string: query_string}) do
-    "#{scheme}://#{host}:#{canonical_port(conn)}#{request_path}?#{query_string}"
+    "#{canonical_scheme(conn)}://#{host}:#{canonical_port(conn)}#{request_path}?#{query_string}"
   end
 
   @spec canonical_port(%Conn{}) :: String.t() | integer
@@ -71,6 +72,14 @@ defmodule PlugCanonicalHost do
     case get_req_header(conn, @forwarded_port_header) do
       [forwarded_port] -> forwarded_port
       [] -> port
+    end
+  end
+
+  @spec canonical_scheme(%Conn{}) :: String.t() | string
+  defp canonical_scheme(conn = %Conn{scheme: scheme}) do
+    case get_req_header(conn, @forwarded_proto_header) do
+      [forwarded_proto] -> forwarded_proto
+      [] -> scheme
     end
   end
 end

--- a/test/plug_canonical_host_test.exs
+++ b/test/plug_canonical_host_test.exs
@@ -36,6 +36,18 @@ defmodule PlugCanonicalHostTest do
     assert get_resp_header(conn, "location") === ["https://example.com/foo?bar=1"]
   end
 
+  test "redirects to forwarded proto" do
+    conn =
+      :get
+      |> conn("http://www.example.com/foo?bar=1")
+      |> put_req_header("x-forwarded-proto", "https")
+      |> put_req_header("x-forwarded-port", "443")
+      |> TestApp.call(TestApp.init([]))
+
+    assert conn.status == 301
+    assert get_resp_header(conn, "location") === ["https://example.com/foo?bar=1"]
+  end
+
   test "does not redirect to canonical host when already on canonical host" do
     conn =
       :get


### PR DESCRIPTION
I added support for the x-forwarded-proto header.
In my case I had my requests coming over 80 with http scheme, with both forwarded-port and forwarded-proto set.
This means the the http://www.host.tld/ should be redirected to https://host.tld

This PR adds support for this header