### PR TITLE
Remove empty query character

### DIFF
--- a/lib/plug_canonical_host.ex
+++ b/lib/plug_canonical_host.ex
@@ -58,6 +58,7 @@ defmodule PlugCanonicalHost do
     conn
     |> request_uri
     |> URI.parse()
+    |> sanitize_empty_query()
     |> Map.put(:host, canonical_host)
     |> URI.to_string()
   end
@@ -82,4 +83,8 @@ defmodule PlugCanonicalHost do
       [] -> scheme
     end
   end
+
+  @spec sanitize_empty_query(%URI{}) :: %URI{}
+  def sanitize_empty_query(uri = %URI{query: ""}), do: Map.put(uri, :query, nil)
+  def sanitize_empty_query(uri), do: uri
 end

--- a/test/plug_canonical_host_test.exs
+++ b/test/plug_canonical_host_test.exs
@@ -17,6 +17,16 @@ defmodule PlugCanonicalHostTest do
   test "redirects to canonical host" do
     conn =
       :get
+      |> conn("http://www.example.com/")
+      |> TestApp.call(TestApp.init([]))
+
+    assert conn.status == 301
+    assert get_resp_header(conn, "location") === ["http://example.com/"]
+  end
+
+  test "redirects to canonical host with query string" do
+    conn =
+      :get
       |> conn("http://www.example.com/foo?bar=1")
       |> TestApp.call(TestApp.init([]))
 


### PR DESCRIPTION
Since Elixir 1.7, this is happening : 

```elixir
URI.to_string(%URI{path: "/", query: ""})
# => "/?"
```

We don’t want this trailing `?`.