### PR TITLE
Replace “ignored hosts” support for “ignore requests” altogether

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ $ curl -sI "http://example.com/foo?bar=1"
 #> Location: http://www.example.com/foo?bar=1
 ```
 
-You can also specify hosts to ignore (ie. that will let requests through without redirecting to the canonical host).
+You can also specify requests to ignore (ie. that will pass through without redirecting to the canonical host).
 
 ```elixir
-PlugCanonicalHost.init(canonical_host: "www.example.com", ignored_hosts: ["www.example.org"])
+PlugCanonicalHost.init(canonical_host: "www.example.com", ignore: fn(%Conn{host: host}) -> host in ["www.example.org"] end)
 ```
 
 Assuming `example.com`, `www.example.com` and `www.example.org` all point to our application:

--- a/lib/plug_canonical_host.ex
+++ b/lib/plug_canonical_host.ex
@@ -38,7 +38,7 @@ defmodule PlugCanonicalHost do
   def init(opts) do
     [
       canonical_host: Keyword.fetch!(opts, :canonical_host),
-      ignored_hosts: Keyword.get(opts, :ignored_hosts, [])
+      ignore: Keyword.get(opts, :ignore, fn _ -> false end)
     ]
   end
 
@@ -46,9 +46,9 @@ defmodule PlugCanonicalHost do
   Call the plug.
   """
   @spec call(%Conn{}, opts) :: Conn.t()
-  def call(conn = %Conn{host: host}, canonical_host: canonical_host, ignored_hosts: ignored_hosts)
+  def call(conn = %Conn{host: host}, canonical_host: canonical_host, ignore: ignore)
       when is_nil(canonical_host) == false and canonical_host !== "" and host !== canonical_host do
-    if host in ignored_hosts do
+    if ignore.(conn) do
       conn
     else
       location = conn |> redirect_location(canonical_host)


### PR DESCRIPTION
Instead of only being able to ignore specific hosts, we’re now able to ignore requests based on anything.

We call the `ignore` function passed as an option with the whole `conn` and only apply the canonical host behavior if it returns `false`.